### PR TITLE
Partial lnknum

### DIFF
--- a/scripts/src/lnknum.py
+++ b/scripts/src/lnknum.py
@@ -53,7 +53,7 @@ def compute_partial_link_DS(s1, s2, idx, filename, dL=1):
         ls[i] = np.vstack((ls[i], s1_start))
         ks[i] = np.vstack((ks[i], s2_start))  
     
-    # compute linking number between 
+    # compute linking number between
     lnkNum = 0.
     norm_factor = 0.
     for a in range(nL-1):
@@ -63,11 +63,17 @@ def compute_partial_link_DS(s1, s2, idx, filename, dL=1):
             lnkNum += _compute_link_DS(ls[i], ks[j])
         norm_factor = ls_Tf[a] * ls_Tf[a]
         # save to disk (running_L, lnkNum, normfactor)
-        filename_extended = filename + "_L{0}_i{1}j{2}.pickle".format(running_L,
-                                                                            idx[0],
-                                                                            idx[1])
-        with open(filename_extended, "wb") as file:
-            pickle.dump((running_L, lnkNum, norm_factor), file)
+        #filename_extended = filename + "_L{0}_i{1}j{2}.pickle".format(running_L,
+        #                                                                   idx[0],
+        #                                                                   idx[1])
+        with open(filename, "rb") as file:
+            lnks, nfs, Ls = pickle.load(file)
+        lnks[idx[0],idx[1],a] = lnkNum
+        nfs[idx[0],idx[1],a] = norm_factor
+        with open(filename, "wb") as file:
+            pickle.dump((lnks, nfs, Ls), file)
+        #with open(filename, "wb") as file:
+        #     pickle.dump((running_L, lnkNum, norm_factor), file)
     return lnkNum
 
 

--- a/scripts/src/lnknum.py
+++ b/scripts/src/lnknum.py
@@ -13,7 +13,7 @@ def compute_link_DS(s1, s2):
     return _compute_link_DS(x1, x2)
 
 
-def compute_partial_link_DS(s1, s2, idx, dL=1):
+def compute_partial_link_DS(s1, s2, idx, filename, dL=1):
     """Compute partial linking numbers between two Streamline objects. 
     Both Streamline objects should have the same lenght L attribute.
     
@@ -61,12 +61,12 @@ def compute_partial_link_DS(s1, s2, idx, dL=1):
         for n in range(a**2, (a+1)**2): # this loop could be parallelized
             i,j = _pairing(n)
             lnkNum += _compute_link_DS(ls[i], ks[j])
-        norm_factor += ls_Tf[a] * ls_Tf[a]
+        norm_factor = ls_Tf[a] * ls_Tf[a]
         # save to disk (running_L, lnkNum, normfactor)
-        filename = "partial_lnks/compute_links_L{0}_i{1}j{2}.pickle".format(running_L,
+        filename_extended = filename + "_L{0}_i{1}j{2}.pickle".format(running_L,
                                                                             idx[0],
                                                                             idx[1])
-        with open(filename, "wb") as file:
+        with open(filename_extended, "wb") as file:
             pickle.dump((running_L, lnkNum, norm_factor), file)
     return lnkNum
 

--- a/scripts/src/lnknum.py
+++ b/scripts/src/lnknum.py
@@ -21,10 +21,12 @@ def compute_partial_link_DS(s1, s2, idx, dL=1):
     
     idx: tuple of ints
         contains the indices of the streamlines for saving to disk intermediate results
+        
+    dL: float or int
     """
     # partition s1 and s2 every dL
     L_values = np.arange(0,s1.L + dL,dL)
-    nL = int(s1.L / dL)
+    nL = len(L_values)
     def split_s(s):
         coord = s.s
         split_coords = np.split(coord, L_values[:-1])
@@ -35,7 +37,7 @@ def compute_partial_link_DS(s1, s2, idx, dL=1):
         split_x = [s.x[idx[i]:idx[i + 1]] for i in range(len(idx) - 1)] 
         # get the normalization factor for the line going from 0 to L_values[k]
         split_Tf = np.array([s.T[idx[i]:idx[i + 1]][-1] for i in range(len(idx) - 1)])
-        return split_x, split_T
+        return split_x, split_Tf
     
     ls, ls_Tf = split_s(s1)
     ks, ks_Tf = split_s(s2)
@@ -54,7 +56,7 @@ def compute_partial_link_DS(s1, s2, idx, dL=1):
     # compute linking number between 
     lnkNum = 0.
     norm_factor = 0.
-    for a in range(nL):
+    for a in range(nL-1):
         running_L = L_values[a]
         for n in range(a**2, (a+1)**2): # this loop could be parallelized
             i,j = _pairing(n)
@@ -64,8 +66,8 @@ def compute_partial_link_DS(s1, s2, idx, dL=1):
         filename = "partial_lnks/compute_links_L{0}_i{1}j{2}.pickle".format(running_L,
                                                                             idx[0],
                                                                             idx[1])
-        with open(filename, "rb") as file:
-            pickle.dump((running_L, lnkNum, normfactor), file)
+        with open(filename, "wb") as file:
+            pickle.dump((running_L, lnkNum, norm_factor), file)
     return lnkNum
 
 
@@ -99,6 +101,6 @@ def _pairing(n):
     fsqrtn = int(np.floor(np.sqrt(n)))
     a = n - fsqrtn * fsqrtn
     if a <= fsqrtn:
-        return a, fsqtrn
+        return a, fsqrtn
     else:
         return fsqrtn, 2*fsqrtn - a


### PR DESCRIPTION

Implementation of compute_partial_link_DS, with the proper closures and traversal. 
 - Code runs, tested on two T=100 streamlines generated previously. Functionality testing is next.
 - the file handling is trash, makes use of a relative path to output into a pre-existing folder. This needs to be fixed :)
 - The splitting method uses np.where. There might be opportunities to improve on the complexity of that?
 - No parallelization happens to compute individual linking number blocks. useful to maximize 
- traversal is handled via a _pairing(int) function that is @jit compiled.
![image](https://user-images.githubusercontent.com/22062721/126832069-cca059d1-4170-4d5c-880a-49ebf583c9ae.png)
